### PR TITLE
Fix ANRs during Position Checks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,18 +52,12 @@ android {
 }
 
 dependencies {
-    implementation 'com.bitmovin.player:player:3.11.1'
+    implementation project(':muxstatssdkbitmovinplayer')
+    t implementation 'com.bitmovin.player:player:3.11.1'
     // This is the version used by Bitmovin. For some reason this must be declared explicitly for buildkite to work
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-}
-
-afterEvaluate {
-    dependencies {
-        r3_11_1Api 'com.mux.stats.sdk.muxstats:muxstatssdkbitmovinplayer_r3_11_1:'+project.ext.versionName
-        r3_11_1_adsApi 'com.mux.stats.sdk.muxstats:muxstatssdkbitmovinplayer_r3_11_1:'+project.ext.versionName
-    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation project(':muxstatssdkbitmovinplayer')
-    t implementation 'com.bitmovin.player:player:3.11.1'
+    implementation 'com.bitmovin.player:player:3.11.1'
     // This is the version used by Bitmovin. For some reason this must be declared explicitly for buildkite to work
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -16,6 +16,7 @@ android {
         buildConfigField("boolean", "SHOULD_REPORT_INSTRUMENTATION_TEST_EVENTS_TO_SERVER", "true")
         buildConfigField("String", "INSTRUMENTATION_TEST_ENVIRONMENT_KEY", "\"YOUR KEY HERE\"")
         var bitmovinLicense = System.getenv("BITMOVIN_LICENSE") == null ? "NOT_CONFIGURED" : System.getenv("BITMOVIN_LICENSE")
+        println("\n\n\n\n\nHEY! My Bitmovin license is $bitmovinLicense\n\n\n\n\n")
         manifestPlaceholders.bitmovinLicense = bitmovinLicense
     }
 

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -16,7 +16,6 @@ android {
         buildConfigField("boolean", "SHOULD_REPORT_INSTRUMENTATION_TEST_EVENTS_TO_SERVER", "true")
         buildConfigField("String", "INSTRUMENTATION_TEST_ENVIRONMENT_KEY", "\"YOUR KEY HERE\"")
         var bitmovinLicense = System.getenv("BITMOVIN_LICENSE") == null ? "NOT_CONFIGURED" : System.getenv("BITMOVIN_LICENSE")
-        println("\n\n\n\n\nHEY! My Bitmovin license is $bitmovinLicense\n\n\n\n\n")
         manifestPlaceholders.bitmovinLicense = bitmovinLicense
     }
 

--- a/muxstatssdkbitmovinplayer/src/main/java/com/mux/stats/sdk/muxstats/bitmovinplayer/MuxStatsSDKBitmovinPlayer.java
+++ b/muxstatssdkbitmovinplayer/src/main/java/com/mux/stats/sdk/muxstats/bitmovinplayer/MuxStatsSDKBitmovinPlayer.java
@@ -524,7 +524,7 @@ public class MuxStatsSDKBitmovinPlayer extends EventBus implements IPlayerListen
 
     @Override
     public boolean isPaused() {
-        return state == PlayerState.PAUSED;
+        return player.get().getPlayer().isPaused();
     }
 
     @Override

--- a/muxstatssdkbitmovinplayer/src/main/java/com/mux/stats/sdk/muxstats/bitmovinplayer/MuxStatsSDKBitmovinPlayer.java
+++ b/muxstatssdkbitmovinplayer/src/main/java/com/mux/stats/sdk/muxstats/bitmovinplayer/MuxStatsSDKBitmovinPlayer.java
@@ -519,12 +519,12 @@ public class MuxStatsSDKBitmovinPlayer extends EventBus implements IPlayerListen
 
     @Override
     public Long getSourceDuration() {
-        return secondsToMs(player.get().getPlayer().getDuration());
+        return secondsToMs(playbackPosition);
     }
 
     @Override
     public boolean isPaused() {
-        return player.get().getPlayer().isPaused();
+        return state == PlayerState.PAUSED;
     }
 
     @Override


### PR DESCRIPTION
Apparently bitmovin's `duration` field is not always stable to call depending on the state of the player. We should prefer to observe bitmovin's state totally asynchronously.

This fixes #8 